### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "dataflow",
     "name_pretty": "Dataflow",
     "product_documentation": "https://cloud.google.com/dataflow/",
-    "client_documentation": "https://googleapis.dev/python/dataflow/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/dataflow/latest",
     "issue_tracker": "",
     "release_level": "beta",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python Client for Cloud Dataflow
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-dataflow-client.svg
    :target: https://pypi.org/project/google-cloud-dataflow-client/
 .. _Cloud Dataflow: https://cloud.google.com/dataflow/
-.. _Client Library Documentation: https://googleapis.dev/python/dataflow/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/dataflow/latest
 .. _Product Documentation:  https://cloud.google.com/dataflow/
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.