### PR TITLE
docs: fix changelog header to consistent size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### [0.5.1](https://github.com/googleapis/python-dataflow-client/compare/v0.5.0...v0.5.1) (2022-05-05)
+## [0.5.1](https://github.com/googleapis/python-dataflow-client/compare/v0.5.0...v0.5.1) (2022-05-05)
 
 
 ### Documentation
@@ -14,7 +14,7 @@
 
 * Add capabilities field to SdkHarnessContainerImage ([#84](https://github.com/googleapis/python-dataflow-client/issues/84)) ([3d86713](https://github.com/googleapis/python-dataflow-client/commit/3d867138d9abc434f83556a0177a89b23e187555))
 
-### [0.4.1](https://github.com/googleapis/python-dataflow-client/compare/v0.4.0...v0.4.1) (2022-03-05)
+## [0.4.1](https://github.com/googleapis/python-dataflow-client/compare/v0.4.0...v0.4.1) (2022-03-05)
 
 
 ### Bug Fixes
@@ -39,7 +39,7 @@
 
 * remove typo in docstring ([#72](https://github.com/googleapis/python-dataflow-client/issues/72)) ([db91cc2](https://github.com/googleapis/python-dataflow-client/commit/db91cc2c65cf43f766385c0f973dd58c4233c9c7))
 
-### [0.3.1](https://www.github.com/googleapis/python-dataflow-client/compare/v0.3.0...v0.3.1) (2021-11-01)
+## [0.3.1](https://www.github.com/googleapis/python-dataflow-client/compare/v0.3.0...v0.3.1) (2021-11-01)
 
 
 ### Bug Fixes
@@ -66,21 +66,21 @@
 
 * add context manager support in client ([#41](https://www.github.com/googleapis/python-dataflow-client/issues/41)) ([2d8fbd5](https://www.github.com/googleapis/python-dataflow-client/commit/2d8fbd5ff487a5e0aeea8cbf6a4d523861bb197a))
 
-### [0.1.5](https://www.github.com/googleapis/python-dataflow-client/compare/v0.1.4...v0.1.5) (2021-09-30)
+## [0.1.5](https://www.github.com/googleapis/python-dataflow-client/compare/v0.1.4...v0.1.5) (2021-09-30)
 
 
 ### Bug Fixes
 
 * improper types in pagers generation ([ce0077b](https://www.github.com/googleapis/python-dataflow-client/commit/ce0077b8b99566a6c97dbbd355eb9a0ea75f5ed3))
 
-### [0.1.4](https://www.github.com/googleapis/python-dataflow-client/compare/v0.1.3...v0.1.4) (2021-09-24)
+## [0.1.4](https://www.github.com/googleapis/python-dataflow-client/compare/v0.1.3...v0.1.4) (2021-09-24)
 
 
 ### Bug Fixes
 
 * add 'dict' annotation type to 'request' ([db5d966](https://www.github.com/googleapis/python-dataflow-client/commit/db5d966111077c2ba286136b9b5aba6a371c8e0d))
 
-### [0.1.3](https://www.github.com/googleapis/python-dataflow-client/compare/v0.1.2...v0.1.3) (2021-08-18)
+## [0.1.3](https://www.github.com/googleapis/python-dataflow-client/compare/v0.1.2...v0.1.3) (2021-08-18)
 
 
 ### Features
@@ -97,14 +97,14 @@
 
 * release as 0.1.3 ([#19](https://www.github.com/googleapis/python-dataflow-client/issues/19)) ([5fa4e3f](https://www.github.com/googleapis/python-dataflow-client/commit/5fa4e3fe0a17f71c719fe5dc093809bb73600b2d))
 
-### [0.1.2](https://www.github.com/googleapis/python-dataflow-client/compare/v0.1.1...v0.1.2) (2021-07-21)
+## [0.1.2](https://www.github.com/googleapis/python-dataflow-client/compare/v0.1.1...v0.1.2) (2021-07-21)
 
 
 ### Bug Fixes
 
 * **deps:** pin 'google-{api,cloud}-core', 'google-auth' to allow 2.x versions ([#13](https://www.github.com/googleapis/python-dataflow-client/issues/13)) ([a85e8aa](https://www.github.com/googleapis/python-dataflow-client/commit/a85e8aac12a35a6bf82c2414d8c4018b64d36cc4))
 
-### [0.1.1](https://www.github.com/googleapis/python-dataflow-client/compare/v0.1.0...v0.1.1) (2021-06-30)
+## [0.1.1](https://www.github.com/googleapis/python-dataflow-client/compare/v0.1.0...v0.1.1) (2021-06-30)
 
 
 ### Miscellaneous Chores


### PR DESCRIPTION
There was a minor issue with patch version releases labeled as an H3 header for changelog. Future changelog headers will always be H2 headers but existing entries must manually be fixed. Towards b/231248807.